### PR TITLE
refs issue:#298 Fix mono compilation errors

### DIFF
--- a/sample/test/TestRange.cs
+++ b/sample/test/TestRange.cs
@@ -8,7 +8,7 @@
 
 using System;
 
-using Gtk;
+using Gtk; using Range = Gtk.Range;
 
 namespace WidgetViewer {
 


### PR DESCRIPTION
Gtk# cannot be compiled with mon 6.0.12.122 (new stable mono) because of an error in the confusion between Gtk.Range and System.Range in the class of TestRange.